### PR TITLE
Use asyncified iNatClient from core

### DIFF
--- a/dronefly_cli/main.py
+++ b/dronefly_cli/main.py
@@ -10,6 +10,7 @@ from dronefly.core.models import Config, User
 from dronefly.core.commands import ArgumentError, CommandError, Context
 from dronefly.core.constants import INAT_USER_DEFAULT_PARAMS
 from rich.console import Console
+from rich.markdown import Markdown
 
 
 console = Console()
@@ -78,8 +79,11 @@ async def do_command(commands, command_str: str, ctx: Context, *args):
             console.print(*response)
         else:
             console.print(response)
-    except (ArgumentError, CommandError) as err:
-        console.print(err)
+    except (ArgumentError, CommandError, LookupError) as err:
+        if commands.format == Format.rich:
+            console.print(Markdown(str(err)))
+        else:
+            console.print(err)
 
 
 def get_context():

--- a/dronefly_cli/main.py
+++ b/dronefly_cli/main.py
@@ -3,6 +3,7 @@ import asyncio
 import os
 import sys
 import readline
+from inspect import getmembers, isroutine
 
 from dronefly.core import Commands, Format
 from dronefly.core.models import Config, User
@@ -16,6 +17,36 @@ histfile = os.path.expanduser("~/.dronefly_history")
 histfile_size = 1000
 
 
+async def help(ctx, *args):
+    """Show help
+    Usage:
+                 help             Show help index
+                 help <command>   Show help for command"""  # noqa: E501
+    if len(args) == 0:
+        commands = [
+            *(
+                member
+                for member in getmembers(Commands, predicate=isroutine)
+                if member[0][0] != "_"
+            ),
+            ("help", help),
+        ]
+        commands.sort(key=lambda x: x[0])
+        longest = max(len(member[0]) for member in commands)
+        response = "\n".join(
+            f"{member[0].ljust(longest)}   {member[1].__doc__.splitlines()[0]}"
+            for member in commands
+        )
+        return response
+    if args[0][0] != "_":
+        command = getattr(Commands, args[0], None)
+        if args[0] == "help":
+            command = help
+        if callable(command):
+            return f"Command:     {args[0]}\nDescription: {command.__doc__}"
+    return f"No help for: {' '.join(args)}"
+
+
 async def do_command(commands, command_str: str, ctx: Context, *args):
     try:
         command = None
@@ -25,12 +56,16 @@ async def do_command(commands, command_str: str, ctx: Context, *args):
             command = getattr(commands, subcommand, None)
             if command:
                 _args.pop(0)
+        if command_str == "help":
+            command = help
         if not command:
             command = getattr(commands, command_str, None)
         if not callable(command):
             raise CommandError(f"No such command: {command_str}")
         # TODO: Use command signatures to provide argument validation and conversion.
-        if (command_str not in ["life", "next", "prev", "page"]) and not _args:
+        if (
+            command_str not in ["life", "next", "prev", "page", "add", "help"]
+        ) and not _args:
             raise ArgumentError("No arguments")
         if command_str in ["next", "prev"] and _args:
             raise ArgumentError("No argument expected")

--- a/dronefly_cli/main.py
+++ b/dronefly_cli/main.py
@@ -12,12 +12,11 @@ from rich.console import Console
 
 
 console = Console()
-commands = Commands(format=Format.rich)
 histfile = os.path.expanduser("~/.dronefly_history")
 histfile_size = 1000
 
 
-async def do_command(command_str: str, ctx: Context, *args):
+async def do_command(commands, command_str: str, ctx: Context, *args):
     try:
         command = None
         _args = [*args]
@@ -80,7 +79,7 @@ def write_history(histfile, histfile_size):
     readline.write_history_file(histfile)
 
 
-async def start_command_loop(ctx, histfile, histfile_size):
+async def start_command_loop(commands, ctx, histfile, histfile_size):
     try:
         read_history(histfile)
 
@@ -97,7 +96,7 @@ async def start_command_loop(ctx, histfile, histfile_size):
             args = _line.split(" ")
             command = args[0]
             args.remove(command)
-            await do_command(command, ctx, *args)
+            await do_command(commands, command, ctx, *args)
     except (KeyboardInterrupt, EOFError):
         write_history(histfile, histfile_size)
         console.print()
@@ -106,14 +105,16 @@ async def start_command_loop(ctx, histfile, histfile_size):
 async def start():
     ctx = get_context()
 
+    loop = asyncio.get_running_loop()
+    commands = Commands(loop=loop, format=Format.rich)
     if len(sys.argv) == 1:
         ctx.per_page = 20
-        await start_command_loop(ctx, histfile, histfile_size)
+        await start_command_loop(commands, ctx, histfile, histfile_size)
     else:
         ctx.per_page = 0
         command = sys.argv[1]
         args = sys.argv[2:]
-        await do_command(command, ctx, *args)
+        await do_command(commands, command, ctx, *args)
 
 
 def main():

--- a/dronefly_cli/main.py
+++ b/dronefly_cli/main.py
@@ -23,6 +23,13 @@ async def help(ctx, *args):
     Usage:
                  help             Show help index
                  help <command>   Show help for command"""  # noqa: E501
+
+    def format_help_index_command(command, command_width):
+        command_help = f"{command[0].replace('_',' ').ljust(command_width)}"
+        if command[1].__doc__:
+            command_help += "    " + command[1].__doc__.splitlines()[0]
+        return command_help
+
     if len(args) == 0:
         commands = [
             *(
@@ -35,16 +42,17 @@ async def help(ctx, *args):
         commands.sort(key=lambda x: x[0])
         longest = max(len(member[0]) for member in commands)
         response = "\n".join(
-            f"{member[0].ljust(longest)}   {member[1].__doc__.splitlines()[0]}"
-            for member in commands
+            format_help_index_command(command, longest) for command in commands
         )
         return response
-    if args[0][0] != "_":
-        command = getattr(Commands, args[0], None)
-        if args[0] == "help":
+    command_name = "_".join(args)
+    if command_name[0] != "_":
+        if command_name == "help":
             command = help
+        else:
+            command = getattr(Commands, command_name, None)
         if callable(command):
-            return f"Command:     {args[0]}\nDescription: {command.__doc__}"
+            return f"Command:     {command_name.replace('_', ' ')}\nDescription: {command.__doc__}"
     return f"No help for: {' '.join(args)}"
 
 

--- a/dronefly_cli/main.py
+++ b/dronefly_cli/main.py
@@ -63,9 +63,7 @@ async def do_command(commands, command_str: str, ctx: Context, *args):
         if not callable(command):
             raise CommandError(f"No such command: {command_str}")
         # TODO: Use command signatures to provide argument validation and conversion.
-        if (
-            command_str not in ["life", "next", "prev", "page", "add", "help"]
-        ) and not _args:
+        if (command_str not in ["life", "next", "prev", "page", "help"]) and not _args:
             raise ArgumentError("No arguments")
         if command_str in ["next", "prev"] and _args:
             raise ArgumentError("No argument expected")


### PR DESCRIPTION
Unify the async support in dronefly-cli with dronefly-core async support for iNatClient.

- Explicitly create an executor to run all coroutines in, both for commands and iNatClient.
- Add a very basic `help` implementation.